### PR TITLE
Wrong sign in quaternion_multiplyv3()

### DIFF
--- a/src/quaternion.c
+++ b/src/quaternion.c
@@ -533,7 +533,7 @@ HYPAPI quaternion *quaternion_multiplyv3(quaternion *self, const vector3 *vT)
 	r.x = self->w*vT->x + self->y*vT->z - self->z*vT->y;
 	r.y = self->w*vT->y - self->x*vT->z + self->z*vT->x;
 	r.z = self->w*vT->z + self->x*vT->y - self->y*vT->x;
-	r.w = self->x*vT->x - self->y*vT->y - self->z*vT->z;
+	r.w = -self->x*vT->x - self->y*vT->y - self->z*vT->z;
 
 	quaternion_set(self, &r); /* overwrite/save it */
 


### PR DESCRIPTION
It should be a minus before `-self->x*vT->x` in 

``` c++
r.w = -self->x*vT->x - self->y*vT->y - self->z*vT->z;
```

Multiply a quaternion Q on a vector V is just a multiplying two quaternions Q and QV, where QV is a quaternion represented a vector V with zero scalar part (`QV->w = 0, QV->x = V->x, QV->y = V->y, QV->z = V->z`):
Q multiply V = Q x (0, V). 

So, if you look on `quaternion_multiply()`, on this string:

`r.w = self->w * qT->w - self->x * qT->x - self->y * qT->y - self->z * qT->z;`

And suggest `qT->w = 0`, you can see, that we obtain:

`r.w =  - self->x * qT->x - self->y * qT->y - self->z * qT->z;`

With a minus before `-self->x*vT->x`
