### PR TITLE
Fix reciprocal aspect ratio

### DIFF
--- a/hypatia.h
+++ b/hypatia.h
@@ -4135,7 +4135,7 @@ HYPAPI struct matrix4 *matrix4_projection_perspective_fovy_rh_EXP(struct matrix4
 	HYP_FLOAT q;
 
 	h = HYP_COT(fovy) / 2.0f;
-	w = h * aspect;
+	w = h / aspect;
 
 	p = zFar / (zNear - zFar);
 	q = zNear * p;


### PR DESCRIPTION
In its current state, aspect ratio for the perspective matrix needs to be supplied as `height / width`, and not `width / height` as it is common.